### PR TITLE
Graph.Facebook and Instagram | Update AdGuard-Home-List.Allow.txt

### DIFF
--- a/AdGuard-Home-List.Allow.txt
+++ b/AdGuard-Home-List.Allow.txt
@@ -125,7 +125,6 @@
 @@||fbcdn.net^$important
 @@||api.facebook.com^$important
 @@||edge-mqtt.facebook.com^$important
-@@||graph.facebook.com^$important
 @@||mqtt.c10r.facebook.com^$important
 @@||portal.fb.com^$important
 @@||star.c10r.facebook.com^$important
@@ -138,7 +137,6 @@
 @@||6-edge-chat.facebook.com^$important
 @@||edge-chat.facebook.com^$important
 @@||mqtt-mini.facebook.com^$important
-@@||graph.instagram.com^$important
 @@||instagram.c10r.facebook.com^$important
 @@||cdninstagram.com^$important
 @@||scontent.xx.fbcdn.net^$important


### PR DESCRIPTION
graph.facebook.com and graph.instagram.com are tracking + ad domains. Blocking them won't affect the functionality of both Facebook and Instagram