### PR TITLE
Removed graph.facebook and instagram

### DIFF
--- a/allowlist/custom/services/facebook.txt
+++ b/allowlist/custom/services/facebook.txt
@@ -7,7 +7,6 @@
 # Facebook Messenger
 @@||api.facebook.com^$important
 @@||edge-mqtt.facebook.com^$important
-@@||graph.facebook.com^$important
 @@||mqtt.c10r.facebook.com^$important
 @@||portal.fb.com^$important
 @@||star.c10r.facebook.com^$important
@@ -23,7 +22,6 @@
 @@||mqtt-mini.facebook.com^$important
 
 # Instagram
-@@||graph.instagram.com^$important
 @@||instagram.c10r.facebook.com^$important
 @@||cdninstagram.com^$important
 


### PR DESCRIPTION
graph.facebook.com and graph.instagram.com are tracking + ad domains. Blocking them won't affect the functionality of both Facebook and Instagram