### PR TITLE
fix(domains): adobe block login on some services

### DIFF
--- a/allowlist/custom/services/adobe.txt
+++ b/allowlist/custom/services/adobe.txt
@@ -1,3 +1,7 @@
 # Adobe licence verification
 @@||lm.licenses.adobe.com^$important
 @@||activate.adobe.com^$important
+
+# Adobe Cloud Privacy
+# https://www.adobe.com/privacy/experience-cloud.html
+@@||omtrdc.net^$important

--- a/allowlist/custom/services/groupeseb.txt
+++ b/allowlist/custom/services/groupeseb.txt
@@ -1,0 +1,2 @@
+# Seb
+@@||account.groupeseb.com^$important

--- a/allowlist/custom/services/salesforce.txt
+++ b/allowlist/custom/services/salesforce.txt
@@ -1,0 +1,4 @@
+# Sales Force
+@@||www.salesforce.com^$important
+@@||login.salesforce.com^$important
+@@||c.salesforce.com^$important

--- a/allowlist/custom/services/xiaomi.txt
+++ b/allowlist/custom/services/xiaomi.txt
@@ -1,2 +1,9 @@
+# Xiaomi
+@@||www.mi.com^$important
+@@||account.xiaomi.com^$important
+@@||ams.buy.mi.com^$important
+
+# API
 @@||api.account.xiaomi.com^$important
 @@||api.xiaomi.com^$important
+@@||app.chat.global.xiaomi.net^$important


### PR DESCRIPTION
## Information
- Resolve #22
- AWS / Google Cloud & Azure was Blocked by Adobe Cloud Privacy
- Xiaomi works with `app.chat.global.xiaomi.net` I hope is enough 

## About #24 

No blocked domains blocked during my tests.
The list available here are enough for privacy.
I think we can resolve #24 and reopen it in case of failure.

 