### PR TITLE
fix: youtube live stream chat avatars

### DIFF
--- a/allowlist/custom/services/youtube.txt
+++ b/allowlist/custom/services/youtube.txt
@@ -11,3 +11,4 @@
 @@||manifest.googlevideo.com^$important
 @@||redirector.googlevideo.com^$important
 @@||googlevideo.com^$important
+@@||yt4.ggpht.com^$important


### PR DESCRIPTION
This fixes YouTube live chat avatar icons not loading issue.