### PR TITLE
fix: rebrandly url shortener

### DIFF
--- a/allowlist/custom/url-shorteners.txt
+++ b/allowlist/custom/url-shorteners.txt
@@ -17,3 +17,5 @@
 @@||short.io^$important
 @@||snip.ly^$important
 @@||kutt.it^$important
+@@||rebrand.ly^$important
+@@||rb.gy^$important


### PR DESCRIPTION
Hey team,

I added two domains related to the shortener service Rebrandly.com

- [rb.gy](rb.gy)
- [rebrand.ly](rebrand.ly)

Thanks,
Gonzalo